### PR TITLE
[Core] Enable SuperBlock logic

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -291,16 +291,15 @@ public:
         consensus.nRuleChangeActivationThreshold = 1512; // 75% of 2016
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
 
-        // StakeCubeCoin : We do not use BudgetPayments, Superblocks and Governance
-        consensus.nBudgetPaymentsStartBlock = INT_MAX; // 2147483647 (= never | requires hardfork to enable)
-        consensus.nBudgetPaymentsCycleBlocks = 21600; // ~(60*24*30)/2
+        // StakeCubeCoin: We do not *yet* use BudgetPayments, Superblocks and Governance
+        consensus.nBudgetPaymentsStartBlock   = INT_MAX; // 2147483647 (= never | requires hardfork to enable)
+        consensus.nBudgetPaymentsCycleBlocks  = 21600; // ~(60*24*30)/2
         consensus.nBudgetPaymentsWindowBlocks = 100;
-        consensus.nSuperblockStartBlock = INT_MAX; // 2147483647 (= never | requires hardfork to enable)
-        consensus.nSuperblockStartHash = uint256();
-        consensus.nSuperblockCycle = 21600; // ~(60*24*30)/2
-        consensus.nGovernanceMinQuorum = 10;
-        consensus.nGovernanceFilterElements = 20000;
-        // End StakeCubeCoin
+        consensus.nSuperblockStartBlock       = 15000; // Hardfork date to re-enable SuperBlocks logic (controlling via spork instead of chain-params)
+        consensus.nSuperblockStartHash        = uint256();
+        consensus.nSuperblockCycle            = 21600; // ~(60*24*30)/2
+        consensus.nGovernanceMinQuorum        = 10;
+        consensus.nGovernanceFilterElements   = 20000;
 
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit         = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime  = 1199145601; // Jan 1st, 2008
@@ -498,16 +497,15 @@ public:
         consensus.nRuleChangeActivationThreshold = 1512; // 75% of 2016
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
 
-        // StakeCubeCoin : We do not use BudgetPayments, Superblocks and Governance
-        consensus.nBudgetPaymentsStartBlock = INT_MAX; // 2147483647 (= never | requires hardfork to enable)
-        consensus.nBudgetPaymentsCycleBlocks = 21600; // ~(60*24*30)/2
+        // StakeCubeCoin: We do not use BudgetPayments, Superblocks and Governance
+        consensus.nBudgetPaymentsStartBlock   = INT_MAX; // 2147483647 (= never | requires hardfork to enable)
+        consensus.nBudgetPaymentsCycleBlocks  = 21600;   // ~(60*24*30)/2
         consensus.nBudgetPaymentsWindowBlocks = 100;
-        consensus.nSuperblockStartBlock = INT_MAX; // 2147483647 (= never | requires hardfork to enable)
-        consensus.nSuperblockStartHash = uint256();
-        consensus.nSuperblockCycle = 21600; // ~(60*24*30)/2
-        consensus.nGovernanceMinQuorum = 10;
-        consensus.nGovernanceFilterElements = 20000;
-        // End StakeCubeCoin
+        consensus.nSuperblockStartBlock       = 300;     // Activated by the time we have enough Masternodes online
+        consensus.nSuperblockStartHash        = uint256();
+        consensus.nSuperblockCycle            = 21600;  // ~(60*24*30)/2
+        consensus.nGovernanceMinQuorum        = 10;
+        consensus.nGovernanceFilterElements   = 20000;
 
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit         = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime  = 1199145601; // Jan 1st, 2008

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -295,7 +295,7 @@ public:
         consensus.nBudgetPaymentsStartBlock   = INT_MAX; // 2147483647 (= never | requires hardfork to enable)
         consensus.nBudgetPaymentsCycleBlocks  = 21600; // ~(60*24*30)/2
         consensus.nBudgetPaymentsWindowBlocks = 100;
-        consensus.nSuperblockStartBlock       = 15000; // Hardfork date to re-enable SuperBlocks logic (controlling via spork instead of chain-params)
+        consensus.nSuperblockStartBlock       = 10000; // Hardfork date to re-enable SuperBlocks logic (controlling via spork instead of chain-params)
         consensus.nSuperblockStartHash        = uint256();
         consensus.nSuperblockCycle            = 21600; // ~(60*24*30)/2
         consensus.nGovernanceMinQuorum        = 10;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -144,6 +144,7 @@ struct Params {
     int nBudgetPaymentsStartBlock;
     int nBudgetPaymentsCycleBlocks;
     int nBudgetPaymentsWindowBlocks;
+    /** Block height and hash at which SuperBlocks become active */
     int nSuperblockStartBlock;
     uint256 nSuperblockStartHash;
     int nSuperblockCycle; // in blocks

--- a/src/masternode/masternode-payments.cpp
+++ b/src/masternode/masternode-payments.cpp
@@ -155,7 +155,7 @@ bool IsBlockValueValid(const CBlock& block, int nBlockHeight, CAmount blockRewar
 
 bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward)
 {
-    if(fDisableGovernance) {
+    if (fDisableGovernance) {
         //there is no budget data to use to check anything, let's just accept the longest chain
         LogPrint(BCLog::MNPAYMENTS, "%s -- WARNING: Not enough data, skipping block payee checks\n", __func__);
         return true;
@@ -163,10 +163,9 @@ bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount bloc
 
     // we are still using budgets, but we have no data about them anymore,
     // we can only check masternode payments
-
     const Consensus::Params& consensusParams = Params().GetConsensus();
 
-    if(nBlockHeight < consensusParams.nSuperblockStartBlock) {
+    if (nBlockHeight < consensusParams.nSuperblockStartBlock) {
         // NOTE: old budget system is disabled since 12.1 and we should never enter this branch
         // anymore when sync is finished (on mainnet). We have no old budget data but these blocks
         // have tons of confirmations and can be safely accepted without payee verification
@@ -176,10 +175,9 @@ bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount bloc
 
     // superblocks started
     // SEE IF THIS IS A VALID SUPERBLOCK
-
-    if(sporkManager.IsSporkActive(SPORK_9_SUPERBLOCKS_ENABLED)) {
-        if(CSuperblockManager::IsSuperblockTriggered(nBlockHeight)) {
-            if(CSuperblockManager::IsValid(txNew, nBlockHeight, blockReward)) {
+    if (sporkManager.IsSporkActive(SPORK_9_SUPERBLOCKS_ENABLED)) {
+        if (CSuperblockManager::IsSuperblockTriggered(nBlockHeight)) {
+            if (CSuperblockManager::IsValid(txNew, nBlockHeight, blockReward)) {
                 LogPrint(BCLog::GOBJECT, "%s -- Valid superblock at height %d: %s", __func__, nBlockHeight, txNew.ToString()); /* Continued */
                 // continue validation, should also pay MN
             } else {
@@ -196,7 +194,7 @@ bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount bloc
     }
 
     // Check for correct masternode payment
-    if(CMasternodePayments::IsTransactionValid(txNew, nBlockHeight, blockReward)) {
+    if (CMasternodePayments::IsTransactionValid(txNew, nBlockHeight, blockReward)) {
         LogPrint(BCLog::MNPAYMENTS, "%s -- Valid masternode payment at height %d: %s", __func__, nBlockHeight, txNew.ToString()); /* Continued */
         return true;
     }


### PR DESCRIPTION
This PR re-enables the SuperBlock logic via chainparams, this will allow the logic flow for Masternode Payee validation again.

All mining pools **must** use a StakeCubeCoin client with this PR included.

This will *not* enable SuperBlock Budget payments themselves, as they are disabled via spork and there are no plans to use SuperBlocks.