### PR TITLE
massively reduced memory footprint

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3038,7 +3038,7 @@ bool CChainState::ActivateBestChain(CValidationState &state, const CChainParams&
     CheckBlockIndex(chainparams.GetConsensus());
 
     // Write changes periodically to disk, after relay.
-    if (!FlushStateToDisk(chainparams, state, FlushStateMode::PERIODIC)) {
+    if (!FlushStateToDisk(chainparams, state, FlushStateMode::ALWAYS)) {
         return false;
     }
 
@@ -3859,7 +3859,7 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     }
 
     if (fCheckForPruning)
-        FlushStateToDisk(chainparams, state, FlushStateMode::NONE); // we just allocated more disk space for block files
+        FlushStateToDisk(chainparams, state, FlushStateMode::ALWAYS); // we just allocated more disk space for block files
 
     CheckBlockIndex(chainparams.GetConsensus());
 


### PR DESCRIPTION
flush cache to disk often, keeps memory usage ~ 1gig resident

Signed-off-by: barrystyle <baz@tiltpool.com>