### PR TITLE
[Core] Softfork upgrade fast-track

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -186,7 +186,7 @@ public:
         consensus.DIP0003EnforcementHeight = 2;
         consensus.DIP0003EnforcementHash   = uint256S("000003173edcde96b0fb18664bb7ca1d1232aa89ce2f5511db210d2b0560aaf2");
         consensus.MinBIP9WarningHeight     = 2;
-        consensus.SoftforkFasttrackHeight  = 391000;
+        consensus.SoftforkFasttrackHeight  = 750000;
 
         /** PoW **/
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -186,6 +186,7 @@ public:
         consensus.DIP0003EnforcementHeight = 2;
         consensus.DIP0003EnforcementHash   = uint256S("000003173edcde96b0fb18664bb7ca1d1232aa89ce2f5511db210d2b0560aaf2");
         consensus.MinBIP9WarningHeight     = 2;
+        consensus.SoftforkFasttrackHeight  = 391000;
 
         /** PoW **/
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -97,6 +97,8 @@ struct Params {
     /** Don't warn about unknown BIP 9 activations below this height.
      * This prevents us from warning about the CSV and DIP activations. */
     int MinBIP9WarningHeight;
+    /** Block height at which all inactive DIPs/BIPs have their params tweaked to fast-track activation speed */
+    int SoftforkFasttrackHeight;
     /**
      * Minimum blocks including miner confirmation of the total of nMinerConfirmationWindow blocks in a retargeting period,
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1845,26 +1845,13 @@ static ThresholdConditionCache warningcache[VERSIONBITS_NUM_BITS] GUARDED_BY(cs_
 static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consensus::Params& consensusparams) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
     AssertLockHeld(cs_main);
 
-    // P2SH is enforced in SCC since block 1
-    unsigned int flags = SCRIPT_VERIFY_P2SH;
+    // P2SH, BIP66 (DERSIG) and BIP65 (CLTV) is enforced in SCC since block 1
+    unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG | SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
 
-    // Enforce the DERSIG (BIP66) rule
-    flags |= SCRIPT_VERIFY_DERSIG;
-
-    // Enforce CHECKLOCKTIMEVERIFY (BIP65) rule
-    flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
-
-    // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY) using versionbits logic.
-    if (VersionBitsState(pindex->pprev, consensusparams, Consensus::DEPLOYMENT_CSV, versionbitscache) == ThresholdState::ACTIVE) {
+    // Start enforcing BIP68 (sequence locks), BIP147 (CSV) and DIP20 (opcodes upgrade) after the 'softfork fast-track' height
+    if (pindex->pprev->nHeight + 1 >= consensusparams.SoftforkFasttrackHeight) {
         flags |= SCRIPT_VERIFY_CHECKSEQUENCEVERIFY;
-    }
-
-    // Start enforcing BIP147 (NULLDUMMY) rule using versionbits logic.
-    if (VersionBitsState(pindex->pprev, consensusparams, Consensus::DEPLOYMENT_BIP147, versionbitscache) == ThresholdState::ACTIVE) {
         flags |= SCRIPT_VERIFY_NULLDUMMY;
-    }
-
-    if (VersionBitsState(pindex->pprev, consensusparams, Consensus::DEPLOYMENT_DIP0020, versionbitscache) == ThresholdState::ACTIVE) {
         flags |= SCRIPT_ENABLE_DIP0020_OPCODES;
     }
 


### PR DESCRIPTION
This PR shifts some pending and/or failed softforks into height-based enforcement upgrades, it's been lightly tested under local conditions.

The following block script flags will be enabled by force upon hitting the block height:
- (BIP68) SCRIPT_VERIFY_CHECKSEQUENCEVERIFY
- (BIP147) SCRIPT_VERIFY_NULLDUMMY
- (DIP20) SCRIPT_ENABLE_DIP0020_OPCODES

Block height has been set for 1 week since the opening of this PR, but can be changed if necessary.